### PR TITLE
Set AIO_NUM_THREADS to available max

### DIFF
--- a/start_notebook.sh
+++ b/start_notebook.sh
@@ -10,5 +10,7 @@ while [ $secs -gt 0 ]; do
    : $((secs--))
 done
 
-export AIO_NUM_THREADS=$(grep -c processor /proc/cpuinfo)
+THREADS=$(grep -c processor /proc/cpuinfo)
+export AIO_NUM_THREADS=$((16>THREADS ? THREADS : 16))
+
 numactl --cpunodebind=0 --membind=0 jupyter notebook --no-browser --allow-root --port=8080

--- a/start_notebook.sh
+++ b/start_notebook.sh
@@ -10,4 +10,5 @@ while [ $secs -gt 0 ]; do
    : $((secs--))
 done
 
+export AIO_NUM_THREADS=$(grep -c processor /proc/cpuinfo)
 numactl --cpunodebind=0 --membind=0 jupyter notebook --no-browser --allow-root --port=8080


### PR DESCRIPTION
Right now we hard-code AIO_NUM_THREADS to 16 in our release images. But what if somebody has smaller shape, for example with 8 cores? This solves the issue for smooth sailing.